### PR TITLE
Set tick to cover only the dataset ranges

### DIFF
--- a/app/src/main/java/app/priceguard/chartsampleapp/MainActivity.kt
+++ b/app/src/main/java/app/priceguard/chartsampleapp/MainActivity.kt
@@ -15,7 +15,7 @@ class MainActivity : AppCompatActivity() {
         
         val chart1 = findViewById<Chart>(R.id.example_chart_1)
         chart1.dataset = ExampleDataset(
-            showXAxis = true,
+            showXAxis = false,
             showYAxis = false,
             touchListener = { v, _ -> v.performClick() },
             data = listOf(
@@ -32,20 +32,18 @@ class MainActivity : AppCompatActivity() {
 
         val chart2 = findViewById<Chart>(R.id.example_chart_2)
         chart2.dataset = ExampleDataset(
-            showXAxis = false,
-            showYAxis = false,
+            showXAxis = true,
+            showYAxis = true,
             touchListener = { v, _ -> v.performClick() },
             data = listOf(
-                ExampleData(2F, 5F),
-                ExampleData(5F, 10F),
-                ExampleData(8F, 1F),
-                ExampleData(9F, 3F),
-                ExampleData(14F, 7F),
-                ExampleData(16F, 8F),
-                ExampleData(18F, 4F),
-                ExampleData(24F, 2F),
-                ExampleData(25F, 8F),
-                ExampleData(26F, 8F)
+                ExampleData(1F, 10F),
+                ExampleData(2F, 1F),
+                ExampleData(3F, 3F),
+                ExampleData(4F, 7F),
+                ExampleData(5F, 8F),
+                ExampleData(6F, 4F),
+                ExampleData(7F, 2F),
+                ExampleData(8F, 8F)
             )
         )
     }

--- a/materialchart/src/main/java/app/priceguard/materialchart/Chart.kt
+++ b/materialchart/src/main/java/app/priceguard/materialchart/Chart.kt
@@ -112,23 +112,17 @@ class Chart @JvmOverloads constructor(
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
         dataset ?: return
-        if (dataset?.showXAxis == false) {
-            if (dataset?.showYAxis == false) {
-                xAxisMargin = zeroDp
-                xGraphPadding = zeroDp
-            } else {
-                yAxisMargin = zeroDp
-                drawYAxis(canvas, yAxisPaint)
-            }
-        }
-        else if (dataset?.showYAxis == false) {
-            if (dataset?.showXAxis == false) {
-                yAxisMargin = zeroDp
-                yGraphPadding = zeroDp
-            } else {
-                xAxisMargin = zeroDp
-                drawXAxis(canvas, xAxisPaint)
-            }
+        if (dataset?.showXAxis == false && dataset?.showYAxis == false) {
+            xAxisMargin = zeroDp
+            xGraphPadding = zeroDp
+            yAxisMargin = zeroDp
+            yGraphPadding = zeroDp
+        } else if (dataset?.showXAxis == true && dataset?.showYAxis == false) {
+            xAxisMargin = zeroDp
+            drawXAxis(canvas, xAxisPaint)
+        } else if (dataset?.showXAxis == false && dataset?.showYAxis == true) {
+            yAxisMargin = zeroDp
+            drawYAxis(canvas, yAxisPaint)
         } else {
             drawYAxis(canvas, yAxisPaint)
             drawXAxis(canvas, xAxisPaint)

--- a/materialchart/src/main/java/app/priceguard/materialchart/Chart.kt
+++ b/materialchart/src/main/java/app/priceguard/materialchart/Chart.kt
@@ -47,10 +47,11 @@ class Chart @JvmOverloads constructor(
     var xAxisSpacing: Dp = Dp(32F)
     var yAxisSpacing: Dp = Dp(32F)
 
-
     var axisStrokeWidth = 3f
     // Tick: lines that are shown in axis with data labels
     var halfTickLength: Dp = Dp(4F)
+    // ZeroDp: Delete Padding. 1dp for show lines in corners and edges
+    var zeroDp = Dp(1F)
 
     // Use Android theme
     private var colorPrimary: Int
@@ -110,8 +111,28 @@ class Chart @JvmOverloads constructor(
 
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
-        drawXAxis(canvas, xAxisPaint)
-        drawYAxis(canvas, yAxisPaint)
+        dataset ?: return
+        if (dataset?.showXAxis == false) {
+            if (dataset?.showYAxis == false) {
+                xAxisMargin = zeroDp
+                xGraphPadding = zeroDp
+            } else {
+                yAxisMargin = zeroDp
+                drawYAxis(canvas, yAxisPaint)
+            }
+        }
+        else if (dataset?.showYAxis == false) {
+            if (dataset?.showXAxis == false) {
+                yAxisMargin = zeroDp
+                yGraphPadding = zeroDp
+            } else {
+                xAxisMargin = zeroDp
+                drawXAxis(canvas, xAxisPaint)
+            }
+        } else {
+            drawYAxis(canvas, yAxisPaint)
+            drawXAxis(canvas, xAxisPaint)
+        }
         drawLine(canvas)
     }
 

--- a/materialchart/src/main/java/app/priceguard/materialchart/Chart.kt
+++ b/materialchart/src/main/java/app/priceguard/materialchart/Chart.kt
@@ -134,7 +134,7 @@ class Chart @JvmOverloads constructor(
         val availableLabels = (availableLabelSpace / xAxisSpacing).value.toInt()
 
         // Calculate how much each ticks should represent
-        val unit = roundToSecondSignificantDigit((maxValue - minValue) / (availableLabels - 1).toFloat())
+        val unit = roundToSecondSignificantDigit((maxValue - minValue) / availableLabels.toFloat())
 
         // Calculate how much labels are actually needed & override spacing
         val neededLabels = ((maxValue - minValue) / unit).toInt()
@@ -219,7 +219,7 @@ class Chart @JvmOverloads constructor(
         val availableLabels = (availableLabelSpace / yAxisSpacing).value.toInt()
 
         // Calculate how much each ticks should represent
-        val unit = roundToSecondSignificantDigit((maxValue - minValue) / (availableLabels - 1).toFloat())
+        val unit = roundToSecondSignificantDigit((maxValue - minValue) / availableLabels.toFloat())
 
         // Calculate how much labels are actually needed & override spacing
         val neededLabels = ((maxValue - minValue) / unit).toInt()


### PR DESCRIPTION
Set tick to cover only the dataset ranges

- Set tick unit to round up: This is because rounding down can cause some data to not exist on the axis
- Automatically override axis spacing after re-calculation of needed labels: When rounding up, it would cover more range than the graph should actually do. Re-adjusting each spacing after the number of labels change will solve this problem

