### PR TITLE
Fix label overlapping in start/end of each axis

### DIFF
--- a/materialchart/src/main/java/app/priceguard/materialchart/Chart.kt
+++ b/materialchart/src/main/java/app/priceguard/materialchart/Chart.kt
@@ -523,6 +523,11 @@ class Chart @JvmOverloads constructor(
         val labelStartPointY: Px =
             (startPointY.toDp(context) + textHeight.toDp(context) / Dp(2F)).toPx(context)
 
+        if (labelStartPointX.value < 0) {
+            // Automatically adjusts the graph margin
+            xAxisMarginStart = Dp(8F) + textWidth.toDp(context) + marginEnd + halfTickLength
+        }
+
         canvas.drawText(labelString, labelStartPointX.value, labelStartPointY.value, paint)
     }
 

--- a/materialchart/src/main/java/app/priceguard/materialchart/Chart.kt
+++ b/materialchart/src/main/java/app/priceguard/materialchart/Chart.kt
@@ -302,7 +302,8 @@ class Chart @JvmOverloads constructor(
             val tickPointX: Px = maxPointX - actualSpacing.toPx(context) * Px(idx.toFloat())
 
             if (tickPointX.value < boundX.value) {
-                // Overlapping first tick. Ignore
+                // Overlapping first tick. Ignore label text
+                drawAxisTick(canvas, tickPointX, tickStartPointY, tickPointX, tickEndPointY, paint)
                 return@forEach
             }
 
@@ -422,7 +423,8 @@ class Chart @JvmOverloads constructor(
             val tickPointY: Px = minPointY - actualSpacing.toPx(context) * Px(idx.toFloat())
 
             if (tickPointY.value < boundY.value) {
-                // Overlapping first tick. Ignore
+                // Overlapping last tick. Ignore label text
+                drawAxisTick(canvas, tickStartPointX, tickPointY, tickEndPointX, tickPointY, paint)
                 return@forEach
             }
 


### PR DESCRIPTION
- Fix label overlapping in start/end of each axis



## Screenshots

Before - After

<img width="1000" alt="image" src="https://github.com/Taewan-P/material-android-chart/assets/27392567/3c61ad56-48f2-42f0-97a1-2625933bd5fe">
