### PR TITLE
Optimize Y Axis min value

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Simple Material You(3) style Android line chart library. Inspired by Google Fina
 In your app build gradle:
 
 ```kts
-implementation("app.priceguard:materialchart:0.2.2")
+implementation("app.priceguard:materialchart:0.2.3")
 ```
 
 Make sure that you have maven central added to the repositories.

--- a/materialchart/build.gradle.kts
+++ b/materialchart/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 val groupName = "app.priceguard"
 val packageName = "materialchart"
-val versionCode = "0.2.2"
+val versionCode = "0.2.3"
 
 group = "$groupName.$packageName"
 version = versionCode

--- a/materialchart/src/main/java/app/priceguard/materialchart/Chart.kt
+++ b/materialchart/src/main/java/app/priceguard/materialchart/Chart.kt
@@ -30,6 +30,7 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import kotlin.math.abs
+import kotlin.math.ceil
 import kotlin.math.floor
 import kotlin.math.log10
 import kotlin.math.pow
@@ -941,26 +942,24 @@ class Chart @JvmOverloads constructor(
         val absNumber = abs(number)
         val digit = floor(log10(absNumber))
         val power = 10F.pow(digit)
+        val roundedNumber =
+            if (number < 0) floor(absNumber / power) * power else ceil(absNumber / power) * power
 
-        val result = (absNumber / power).roundToInt() * power
-
-        if (result < absNumber) {
-            return result + power
-        }
-
-        return if (number < 0) -result else result
+        return if (number < 0) -roundedNumber else roundedNumber
     }
 
     private fun roundDownToSignificantDigit(number: Float, significantDigit: Int): Float {
         if (number == 0F) {
             return 0F
         }
+
         val absNumber = abs(number)
         val originalNumberDigit = absNumber.toInt().toString().length
         val digitToRound = originalNumberDigit - significantDigit
         val digit = floor(log10(absNumber)).toInt()
         val power = 10F.pow(digit - digitToRound)
-        val roundedNumber = floor(absNumber / power) * power
+        val roundedNumber =
+            if (number < 0) ceil(absNumber / power) * power else floor(absNumber / power) * power
 
         return if (number < 0) -roundedNumber else roundedNumber
     }

--- a/materialchart/src/main/java/app/priceguard/materialchart/Chart.kt
+++ b/materialchart/src/main/java/app/priceguard/materialchart/Chart.kt
@@ -400,11 +400,7 @@ class Chart @JvmOverloads constructor(
 
         // Calculate how much each ticks should represent
         val difference = getDifference(maxValue, minValue)
-        val unit = if (difference > realMinValue - minValue) {
-            roundUpToSecondSignificantDigit(difference / (availableLabels - 1).toFloat())
-        } else {
-            roundUpToSecondSignificantDigit(maxValue / (availableLabels - 1).toFloat())
-        }
+        val unit = roundUpToSecondSignificantDigit(difference / (availableLabels - 1).toFloat())
         val actualSpacing = availableLabelSpace * Dp(unit / difference)
 
         // Calculate how much labels are actually needed & override spacing
@@ -902,11 +898,7 @@ class Chart @JvmOverloads constructor(
 
         // Calculate how much each ticks should represent
         val difference = getDifference(maxY, minY)
-        val unit = if (difference > realMinY - minY) {
-            roundUpToSecondSignificantDigit(difference / (availableLabels - 1).toFloat())
-        } else {
-            roundUpToSecondSignificantDigit(maxY / (availableLabels - 1).toFloat())
-        }
+        val unit = roundUpToSecondSignificantDigit(difference / (availableLabels - 1).toFloat())
         val actualSpacing = availableLabelSpace * Dp(unit / difference)
         val minToRealMinSpacing = Dp(realMinY - minY) * actualSpacing / Dp(unit)
 

--- a/materialchart/src/main/java/app/priceguard/materialchart/Chart.kt
+++ b/materialchart/src/main/java/app/priceguard/materialchart/Chart.kt
@@ -388,7 +388,10 @@ class Chart @JvmOverloads constructor(
 
         val maxValue = chartData.maxOf { it.y }
         val realMinValue = chartData.minOf { it.y }
-        val minValue = roundDownToSecondSignificantDigit(realMinValue, (maxValue - realMinValue).toInt().toString().length)
+        val minValue = roundDownToSignificantDigit(
+            realMinValue,
+            (maxValue - realMinValue).toInt().toString().length
+        )
 
         // Calculate available axis space
         val availableSpace: Dp =
@@ -885,7 +888,8 @@ class Chart @JvmOverloads constructor(
 
         val maxY = chartData.maxOf { it.y }
         val realMinY = chartData.minOf { it.y }
-        val minY = roundDownToSecondSignificantDigit(realMinY, (maxY - realMinY).toInt().toString().length)
+        val minY =
+            roundDownToSignificantDigit(realMinY, (maxY - realMinY).toInt().toString().length)
 
         val availableSpace: Dp =
             Px(height.toFloat()).toDp(context) - yAxisMarginStart - yAxisMarginEnd
@@ -902,7 +906,10 @@ class Chart @JvmOverloads constructor(
         val actualSpacing = availableLabelSpace * Dp(unit / difference)
         val minToRealMinSpacing = Dp(realMinY - minY) * actualSpacing / Dp(unit)
 
-        val minPointY: Px = (axisStartPointY.toDp(context) - (yAxisPadding / Dp(2F)) - minToRealMinSpacing).toPx(context)
+        val minPointY: Px =
+            (axisStartPointY.toDp(context) - (yAxisPadding / Dp(2F)) - minToRealMinSpacing).toPx(
+                context
+            )
         val maxPointY: Px = (axisEndPointY.toDp(context) + yAxisPadding / Dp(2F)).toPx(context)
 
         if (maxY == realMinY) {
@@ -944,7 +951,7 @@ class Chart @JvmOverloads constructor(
         return if (number < 0) -result else result
     }
 
-    private fun roundDownToSecondSignificantDigit(number: Float, significantDigit: Int): Float {
+    private fun roundDownToSignificantDigit(number: Float, significantDigit: Int): Float {
         if (number == 0F) {
             return 0F
         }

--- a/materialchart/src/main/java/app/priceguard/materialchart/Chart.kt
+++ b/materialchart/src/main/java/app/priceguard/materialchart/Chart.kt
@@ -400,7 +400,11 @@ class Chart @JvmOverloads constructor(
 
         // Calculate how much each ticks should represent
         val difference = getDifference(maxValue, minValue)
-        val unit = roundToSecondSignificantDigit(difference / (availableLabels - 1).toFloat())
+        val unit = if (difference > realMinValue - minValue) {
+            roundToSecondSignificantDigit(difference / (availableLabels - 1).toFloat())
+        } else {
+            roundToSecondSignificantDigit(maxValue / (availableLabels - 1).toFloat())
+        }
         val actualSpacing = availableLabelSpace * Dp(unit / difference)
 
         // Calculate how much labels are actually needed & override spacing
@@ -432,7 +436,7 @@ class Chart @JvmOverloads constructor(
 
         yAxisPaint.setTickPaint()
 
-        if (minValue == maxValue) {
+        if (realMinValue == maxValue) {
             val middlePointY = (minPointY + maxPointY) / Px(2F)
             drawAxisTick(
                 canvas,
@@ -898,7 +902,11 @@ class Chart @JvmOverloads constructor(
 
         // Calculate how much each ticks should represent
         val difference = getDifference(maxY, minY)
-        val unit = roundToSecondSignificantDigit(difference / (availableLabels - 1).toFloat())
+        val unit = if (difference > realMinY - minY) {
+            roundToSecondSignificantDigit(difference / (availableLabels - 1).toFloat())
+        } else {
+            roundToSecondSignificantDigit(maxY / (availableLabels - 1).toFloat())
+        }
         val actualSpacing = availableLabelSpace * Dp(unit / difference)
         val minToRealMinSpacing = Dp(realMinY - minY) * actualSpacing / Dp(unit)
 
@@ -906,7 +914,7 @@ class Chart @JvmOverloads constructor(
         val maxPointY: Px = (axisEndPointY.toDp(context) + yAxisPadding / Dp(2F)).toPx(context)
 
         if (maxY == realMinY) {
-            val middlePointY = (minPointY + maxPointY) / Px(2F)
+            val middlePointY = (minPointY + minToRealMinSpacing.toPx(context) + maxPointY) / Px(2F)
             return Pair(middlePointY, middlePointY)
         }
 

--- a/materialchart/src/main/java/app/priceguard/materialchart/Chart.kt
+++ b/materialchart/src/main/java/app/priceguard/materialchart/Chart.kt
@@ -257,7 +257,7 @@ class Chart @JvmOverloads constructor(
 
         // Calculate how much each ticks should represent
         val difference = getDifference(maxValue, minValue)
-        val unit = roundToSecondSignificantDigit(difference / (availableLabels - 1).toFloat())
+        val unit = roundUpToSecondSignificantDigit(difference / (availableLabels - 1).toFloat())
         val actualSpacing = availableLabelSpace * Dp(unit / difference)
 
         // Calculate how much labels are actually needed & override spacing
@@ -401,9 +401,9 @@ class Chart @JvmOverloads constructor(
         // Calculate how much each ticks should represent
         val difference = getDifference(maxValue, minValue)
         val unit = if (difference > realMinValue - minValue) {
-            roundToSecondSignificantDigit(difference / (availableLabels - 1).toFloat())
+            roundUpToSecondSignificantDigit(difference / (availableLabels - 1).toFloat())
         } else {
-            roundToSecondSignificantDigit(maxValue / (availableLabels - 1).toFloat())
+            roundUpToSecondSignificantDigit(maxValue / (availableLabels - 1).toFloat())
         }
         val actualSpacing = availableLabelSpace * Dp(unit / difference)
 
@@ -903,9 +903,9 @@ class Chart @JvmOverloads constructor(
         // Calculate how much each ticks should represent
         val difference = getDifference(maxY, minY)
         val unit = if (difference > realMinY - minY) {
-            roundToSecondSignificantDigit(difference / (availableLabels - 1).toFloat())
+            roundUpToSecondSignificantDigit(difference / (availableLabels - 1).toFloat())
         } else {
-            roundToSecondSignificantDigit(maxY / (availableLabels - 1).toFloat())
+            roundUpToSecondSignificantDigit(maxY / (availableLabels - 1).toFloat())
         }
         val actualSpacing = availableLabelSpace * Dp(unit / difference)
         val minToRealMinSpacing = Dp(realMinY - minY) * actualSpacing / Dp(unit)
@@ -934,7 +934,7 @@ class Chart @JvmOverloads constructor(
         return format.format(date)
     }
 
-    private fun roundToSecondSignificantDigit(number: Float): Float {
+    private fun roundUpToSecondSignificantDigit(number: Float): Float {
         if (number == 0F) {
             return 0F
         }

--- a/materialchart/src/main/java/app/priceguard/materialchart/Chart.kt
+++ b/materialchart/src/main/java/app/priceguard/materialchart/Chart.kt
@@ -957,9 +957,9 @@ class Chart @JvmOverloads constructor(
         }
 
         val absNumber = abs(number)
-        val log10 = floor(log10(absNumber.toDouble())).toInt()
-        val factor = 10.0.pow(log10 - 1).toFloat()
-        val roundedNumber = floor(absNumber / factor) * factor
+        val digit = floor(log10(absNumber)).toInt()
+        val power = 10F.pow(digit - 1)
+        val roundedNumber = floor(absNumber / power) * power
 
         return if (number < 0) -roundedNumber else roundedNumber
     }

--- a/materialchart/src/main/java/app/priceguard/materialchart/Chart.kt
+++ b/materialchart/src/main/java/app/priceguard/materialchart/Chart.kt
@@ -388,7 +388,7 @@ class Chart @JvmOverloads constructor(
 
         val maxValue = chartData.maxOf { it.y }
         val realMinValue = chartData.minOf { it.y }
-        val minValue = roundDownToSecondSignificantDigit(realMinValue)
+        val minValue = roundDownToSecondSignificantDigit(realMinValue, (maxValue - realMinValue).toInt().toString().length)
 
         // Calculate available axis space
         val availableSpace: Dp =
@@ -885,7 +885,7 @@ class Chart @JvmOverloads constructor(
 
         val maxY = chartData.maxOf { it.y }
         val realMinY = chartData.minOf { it.y }
-        val minY = roundDownToSecondSignificantDigit(realMinY)
+        val minY = roundDownToSecondSignificantDigit(realMinY, (maxY - realMinY).toInt().toString().length)
 
         val availableSpace: Dp =
             Px(height.toFloat()).toDp(context) - yAxisMarginStart - yAxisMarginEnd
@@ -943,14 +943,15 @@ class Chart @JvmOverloads constructor(
         return result
     }
 
-    private fun roundDownToSecondSignificantDigit(number: Float): Float {
+    private fun roundDownToSecondSignificantDigit(number: Float, significantDigit: Int): Float {
         if (number == 0F) {
             return 0F
         }
-
         val absNumber = abs(number)
+        val originalNumberDigit = absNumber.toInt().toString().length
+        val digitToRound = originalNumberDigit - significantDigit
         val digit = floor(log10(absNumber)).toInt()
-        val power = 10F.pow(digit - 1)
+        val power = 10F.pow(digit - digitToRound)
         val roundedNumber = floor(absNumber / power) * power
 
         return if (number < 0) -roundedNumber else roundedNumber

--- a/materialchart/src/main/java/app/priceguard/materialchart/Chart.kt
+++ b/materialchart/src/main/java/app/priceguard/materialchart/Chart.kt
@@ -931,16 +931,17 @@ class Chart @JvmOverloads constructor(
             return 0F
         }
 
-        val digit = floor(log10(number))
+        val absNumber = abs(number)
+        val digit = floor(log10(absNumber))
         val power = 10F.pow(digit)
 
-        val result = (number / power).roundToInt() * power
+        val result = (absNumber / power).roundToInt() * power
 
-        if (result < number) {
+        if (result < absNumber) {
             return result + power
         }
 
-        return result
+        return if (number < 0) -result else result
     }
 
     private fun roundDownToSecondSignificantDigit(number: Float, significantDigit: Int): Float {


### PR DESCRIPTION
Previously, we optimize the y axis min value by setting the min axis value to the source data min value. Not just normalizing the tick value, we rounded the tick value to improve user experience because sometimes it can be hard to read the difference between each tick. However, this method still had a flaw. When the min value's last digits of the source data is not clean, the rounded tick can be still uncomfortable to read. To improve this, the min value of the axis is rounded down, and the rest of the logic that draws the gradation and graph lines are calculated based on the change min-max value.

**Before (Tick optimization before, after)**
<img width="300" alt="image" src="https://github.com/Taewan-P/material-android-chart/assets/27392567/428d3b40-0efb-4e14-b9e1-962fb0686903">

**After (Y axis min value optimization)**
<img width="300" alt="image" src="https://github.com/Taewan-P/material-android-chart/assets/27392567/7ddbcff2-5bfe-4a5f-b708-2f69483c2c00">


